### PR TITLE
Fix memory leak of PsDecoder taking a CmdLn config without dropping it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ extern crate pocketsphinx_sys as bindings;
 
 use std::ptr;
 use std::ffi::{CStr, CString};
-use std::mem;
 use libc::c_char;
 
 pub use search::*;
@@ -72,10 +71,6 @@ impl CmdLn {
     pub unsafe fn get_float64(&self, name: &str) -> f64 {
         self.get_float(name) as f64
     }
-
-    fn into_raw(mut self) -> *mut bindings::cmd_ln_t {
-        mem::replace(&mut self.raw, ptr::null_mut())
-    }
 }
 
 impl Drop for CmdLn {
@@ -90,13 +85,15 @@ impl Drop for CmdLn {
 
 pub struct PsDecoder {
     raw: *mut bindings::ps_decoder_t,
+    #[allow(dead_code)]
+    config: CmdLn,
 }
 
 impl PsDecoder {
     pub fn init(config: CmdLn) -> Self {
-        let raw = unsafe { bindings::ps_init(config.into_raw()) };
+        let raw = unsafe { bindings::ps_init(config.raw) };
         assert!(!raw.is_null());
-        PsDecoder{raw: raw}
+        PsDecoder{raw: raw, config: config}
     }
 
     pub fn start_utt(&self, utt_id: Option<&str>) -> Result<()>  {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,7 @@ impl CmdLn {
 impl Drop for CmdLn {
     fn drop(&mut self) {
         if !self.raw.is_null() {
-            let ref_count = unsafe { bindings::cmd_ln_free_r(self.raw) };
-            assert!(ref_count == 0);
+            unsafe { bindings::cmd_ln_free_r(self.raw) };
         }
     }
 }
@@ -85,15 +84,13 @@ impl Drop for CmdLn {
 
 pub struct PsDecoder {
     raw: *mut bindings::ps_decoder_t,
-    #[allow(dead_code)]
-    config: CmdLn,
 }
 
 impl PsDecoder {
     pub fn init(config: CmdLn) -> Self {
         let raw = unsafe { bindings::ps_init(config.raw) };
         assert!(!raw.is_null());
-        PsDecoder{raw: raw, config: config}
+        PsDecoder{raw: raw}
     }
 
     pub fn start_utt(&self, utt_id: Option<&str>) -> Result<()>  {


### PR DESCRIPTION
Hey,

I found a memory leak of your wrapper using valgrind and fixed it to my best knowledge
(I just started learning rust). Maybe you'll find a better way to fix it.

Valgrind output:

```
==29897== HEAP SUMMARY:
==29897==     in use at exit: 12,498 bytes in 324 blocks
==29897==   total heap usage: 410,308 allocs, 409,984 frees, 147,592,538 bytes allocated
==29897==
==29897== 12,498 (32 direct, 12,466 indirect) bytes in 1 blocks are definitely lost in loss record 50 of 50
==29897==    at 0x4C2CD30: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==29897==    by 0x508CE28: __ckd_calloc__ (ckd_alloc.c:157)
==29897==    by 0x5092ACD: cmd_ln_parse_r (cmd_ln.c:564)
==29897==    by 0x114DA9: pocketsphinx::CmdLn::init::hdff10669c9fc8130 (lib.rs:30)
==29897==    by 0x10F826: caia::main::h51224b636fb2dfcf (main.rs:10)
==29897==    by 0x120295: call_once<fn(),()> (ops.rs:2606)
==29897==    by 0x120295: std::panicking::try::do_call::h689a21caeeef92aa (panicking.rs:454)
==29897==    by 0x126DEA: __rust_maybe_catch_panic (lib.rs:98)
==29897==    by 0x120A7A: try<(),fn()> (panicking.rs:433)
==29897==    by 0x120A7A: catch_unwind<fn(),()> (panic.rs:361)
==29897==    by 0x120A7A: std::rt::lang_start::hf63d494cb7dd034c (rt.rs:57)
==29897==    by 0x10F922: main (in /home/paspartout/dev/pro/caia/pt3/caia/target/debug/caia)
==29897==
==29897== LEAK SUMMARY:
==29897==    definitely lost: 32 bytes in 1 blocks
==29897==    indirectly lost: 12,466 bytes in 323 blocks
==29897==      possibly lost: 0 bytes in 0 blocks
==29897==    still reachable: 0 bytes in 0 blocks
==29897==         suppressed: 0 bytes in 0 blocks
==29897==
==29897== For counts of detected and suppressed errors, rerun with: -v
==29897== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

Once a the raw config was given to the PsDecoder by ps_init(config.into_raw())
there was no way to free the memory by dropping the CmdLn anymore.

There are also some other warnings by [rust-clippy](https://github.com/Manishearth/rust-clippy) that you might wan't to take a look at.

Thanks for the wrapper though! It helped me understanding how rust does
the FFI bindings and I am going to use it in a project of mine :+1: .